### PR TITLE
Reverted jar-with-dependencies and safe version updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
     </licenses>
 
     <properties>
-        <spring.version>4.3.5.RELEASE</spring.version>
-        <aspectj.version>1.7.4</aspectj.version>
+        <spring.version>4.3.13.RELEASE</spring.version>
+        <aspectj.version>1.8.13</aspectj.version>
         <slf4j.version>1.7.22</slf4j.version>
         <jaxb.version>2.3.0</jaxb.version>
     </properties>
@@ -279,25 +279,6 @@
                 </configuration>
             </plugin>
 -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-toolchains-plugin</artifactId>

--- a/src/main/java/org/cruk/genologics/api/http/GenologicsFailureResponseErrorHandler.java
+++ b/src/main/java/org/cruk/genologics/api/http/GenologicsFailureResponseErrorHandler.java
@@ -133,28 +133,4 @@ public class GenologicsFailureResponseErrorHandler extends DefaultResponseErrorH
         // continue as before.
         super.handleError(response);
     }
-
-    /**
-     * Read the response body from the input stream into a byte array.
-     *
-     * @param response The HTTP response.
-     *
-     * @return The response body, as bytes.
-     */
-    private byte[] getResponseBody(ClientHttpResponse response)
-    {
-        try
-        {
-            InputStream responseBody = response.getBody();
-            if (responseBody != null)
-            {
-                return FileCopyUtils.copyToByteArray(responseBody);
-            }
-        }
-        catch (IOException ex)
-        {
-            // ignore
-        }
-        return new byte[0];
-    }
 }


### PR DESCRIPTION
The Maven `jar-with-dependencies` target is useless, as it does not properly merge Spring resources that are stored with fixed names in multiple JARs.  Now relying on `sbt-assembly` in the `clarity-automation` project to do the correct merging.